### PR TITLE
now shows Z_test, demonstrates generalization

### DIFF
--- a/examples/gaussian3d.ipynb
+++ b/examples/gaussian3d.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "Z_test = net(X_test).detach()\n",
     "ue.plot_3d(X_test, y_test, 'X_test')\n",
-    "ue.plot_3d(X_test, y_test, 'Z_test')"
+    "ue.plot_3d(Z_test, y_test, 'Z_test')"
    ]
   },
   {


### PR DESCRIPTION
Small typo in demo, but originally appeared that ReduNet didn't generalize.